### PR TITLE
Frevent a crash

### DIFF
--- a/common/enhancedportals/item/ItemPortalModifierUpgrade.java
+++ b/common/enhancedportals/item/ItemPortalModifierUpgrade.java
@@ -85,7 +85,7 @@ public class ItemPortalModifierUpgrade extends Item
     @Override
     public String getUnlocalizedName(ItemStack par1ItemStack)
     {
-        return super.getUnlocalizedName() + "." + Upgrade.getUpgradeNames()[MathHelper.clampInt(par1ItemStack.getItemDamage(), 0, textures.length)];
+        return super.getUnlocalizedName() + "." + Upgrade.getUpgradeNames()[MathHelper.clampInt(par1ItemStack.getItemDamage(), 0, Upgrade.getUpgradeNames().length)];
     }
 
     @Override


### PR DESCRIPTION
http://pastebin.com/Y76TGRrd

Happened because the getUnlocalizedName() function was called before the textures were initialized. Now it works.
