### PR TITLE
Add null check for onEntityEnterPortal

### DIFF
--- a/common/uk/co/shadeddimensions/ep3/tileentity/frame/TilePortalController.java
+++ b/common/uk/co/shadeddimensions/ep3/tileentity/frame/TilePortalController.java
@@ -702,7 +702,9 @@ public class TilePortalController extends TilePortalPart
             }
 
             TileStabilizerMain dbs = blockManager.getDimensionalBridgeStabilizerTile();
-            dbs.onEntityEnterPortal(uID, entity, portal);
+            if (dbs != null) {
+              dbs.onEntityEnterPortal(uID, entity, portal);
+            }
         }
     }
 


### PR DESCRIPTION
Haven't tested this yet, the build script doesn't work for me (on Linux), but this should at least stop the crashes.
