### PR TITLE
Fixed inventory desyncs after using portal GUIs

### DIFF
--- a/src/main/java/uk/co/shadeddimensions/ep3/client/gui/GuiDiallingDevice.java
+++ b/src/main/java/uk/co/shadeddimensions/ep3/client/gui/GuiDiallingDevice.java
@@ -15,13 +15,12 @@ import uk.co.shadeddimensions.ep3.item.ItemPaintbrush;
 import uk.co.shadeddimensions.ep3.item.ItemWrench;
 import uk.co.shadeddimensions.ep3.lib.Localization;
 import uk.co.shadeddimensions.ep3.network.ClientProxy;
-import uk.co.shadeddimensions.ep3.network.GuiHandler;
 import uk.co.shadeddimensions.ep3.network.PacketHandlerClient;
 import uk.co.shadeddimensions.ep3.network.packet.PacketTextureData;
 import uk.co.shadeddimensions.ep3.tileentity.portal.TileController;
 import uk.co.shadeddimensions.ep3.tileentity.portal.TileDiallingDevice;
 import uk.co.shadeddimensions.ep3.tileentity.portal.TileDiallingDevice.GlyphElement;
-import uk.co.shadeddimensions.library.gui.GuiBase;
+import uk.co.shadeddimensions.library.gui.GuiBaseContainer;
 import uk.co.shadeddimensions.library.gui.element.ElementButton;
 import uk.co.shadeddimensions.library.gui.element.ElementButtonIcon;
 import uk.co.shadeddimensions.library.gui.element.ElementScrollBar;
@@ -29,7 +28,7 @@ import uk.co.shadeddimensions.library.gui.element.ElementScrollPanel;
 import uk.co.shadeddimensions.library.gui.element.ElementScrollPanelOverlay;
 import cpw.mods.fml.common.network.PacketDispatcher;
 
-public class GuiDiallingDevice extends GuiBase
+public class GuiDiallingDevice extends GuiBaseContainer
 {
     TileController controller;
     TileDiallingDevice dial;
@@ -46,6 +45,7 @@ public class GuiDiallingDevice extends GuiBase
     public GuiDiallingDevice(TileDiallingDevice dialler)
     {
         super(new ResourceLocation("enhancedportals", "textures/gui/diallingDevice.png"));
+        drawInventory = false;
         dial = dialler;
         controller = dialler.getPortalController();
         xSize = 256;
@@ -129,9 +129,9 @@ public class GuiDiallingDevice extends GuiBase
     }
 
     @Override
-    public void drawGuiBackgroundLayer(float f, int i, int j)
+    public void drawGuiContainerBackgroundLayer(float f, int i, int j)
     {
-        super.drawGuiBackgroundLayer(f, i, j);
+        super.drawGuiContainerBackgroundLayer(f, i, j);
 
         if (showOverlay)
         {
@@ -146,9 +146,9 @@ public class GuiDiallingDevice extends GuiBase
     }
 
     @Override
-    public void drawGuiForegroundLayer(int mouseX, int mouseY)
+    public void drawGuiContainerForegroundLayer(int mouseX, int mouseY)
     {
-        super.drawGuiForegroundLayer(mouseX, mouseY);
+        super.drawGuiContainerForegroundLayer(mouseX, mouseY);
 
         fontRenderer.drawStringWithShadow(Localization.getGuiString("dialDevice"), xSize / 2 - fontRenderer.getStringWidth(Localization.getGuiString("dialDevice")) / 2, -13, showOverlay ? 0x444444 : 0xFFFFFF);
         fontRenderer.drawString(Localization.getGuiString("storedIdentifiers"), 7, 7, showOverlay ? 0x222222 : 0x404040);

--- a/src/main/java/uk/co/shadeddimensions/ep3/client/gui/GuiNetworkInterface.java
+++ b/src/main/java/uk/co/shadeddimensions/ep3/client/gui/GuiNetworkInterface.java
@@ -14,10 +14,10 @@ import uk.co.shadeddimensions.ep3.lib.Localization;
 import uk.co.shadeddimensions.ep3.network.PacketHandlerClient;
 import uk.co.shadeddimensions.ep3.portal.GlyphIdentifier;
 import uk.co.shadeddimensions.ep3.tileentity.portal.TileController;
-import uk.co.shadeddimensions.library.gui.GuiBase;
+import uk.co.shadeddimensions.library.gui.GuiBaseContainer;
 import uk.co.shadeddimensions.library.util.GuiUtils;
 
-public class GuiNetworkInterface extends GuiBase
+public class GuiNetworkInterface extends GuiBaseContainer
 {
     ElementGlyphSelector selector;
     ElementGlyphIdentifier identifier;
@@ -28,6 +28,7 @@ public class GuiNetworkInterface extends GuiBase
     public GuiNetworkInterface(TileController tile)
     {
         super(new ResourceLocation("enhancedportals", "textures/gui/networkInterface.png"));
+        drawInventory = false;
         ySize = 144;
         controller = tile;
         overlayActive = false;
@@ -98,9 +99,9 @@ public class GuiNetworkInterface extends GuiBase
     }
 
     @Override
-    public void drawGuiForegroundLayer(int x, int y)
+    public void drawGuiContainerForegroundLayer(int x, int y)
     {
-        super.drawGuiForegroundLayer(x, y);
+        super.drawGuiContainerForegroundLayer(x, y);
 
         drawCenteredString(fontRenderer, Localization.getGuiString("networkInterface"), xSize / 2, -13, 0xFFFFFF);
         fontRenderer.drawString(Localization.getGuiString("networkIdentifier"), 8, 8, 0x404040);

--- a/src/main/java/uk/co/shadeddimensions/ep3/client/gui/GuiPortalController.java
+++ b/src/main/java/uk/co/shadeddimensions/ep3/client/gui/GuiPortalController.java
@@ -17,12 +17,12 @@ import uk.co.shadeddimensions.ep3.lib.Localization;
 import uk.co.shadeddimensions.ep3.network.PacketHandlerClient;
 import uk.co.shadeddimensions.ep3.portal.GlyphIdentifier;
 import uk.co.shadeddimensions.ep3.tileentity.portal.TileController;
-import uk.co.shadeddimensions.library.gui.GuiBase;
+import uk.co.shadeddimensions.library.gui.GuiBaseContainer;
 import uk.co.shadeddimensions.library.gui.element.ElementItemIconWithCount;
 import uk.co.shadeddimensions.library.gui.element.ElementItemStackPanel;
 import uk.co.shadeddimensions.library.util.GuiUtils;
 
-public class GuiPortalController extends GuiBase
+public class GuiPortalController extends GuiBaseContainer
 {
     TileController controller;
     GuiButton resetButton, saveButton, publicButton;
@@ -37,6 +37,7 @@ public class GuiPortalController extends GuiBase
     public GuiPortalController(TileController tile)
     {
         super(new ResourceLocation("enhancedportals", "textures/gui/portalController.png"));
+        drawInventory = false;
         ySize = 144;
         controller = tile;
         overlayActive = false;
@@ -168,7 +169,7 @@ public class GuiPortalController extends GuiBase
     }
 
     @Override
-    public void drawGuiForegroundLayer(int x, int y)
+    public void drawGuiContainerForegroundLayer(int x, int y)
     {
         drawCenteredString(fontRenderer, Localization.getGuiString("portalController"), xSize / 2, -13, 0xFFFFFF);
         fontRenderer.drawString(Localization.getGuiString("uniqueIdentifier"), 8, 8, 0x404040);
@@ -198,7 +199,7 @@ public class GuiPortalController extends GuiBase
             fontRenderer.drawString(warningMessage, xSize / 2 - fontRenderer.getStringWidth(warningMessage) / 2, 125, 0xFF0000);
         }
 
-        super.drawGuiForegroundLayer(x, y);
+        super.drawGuiContainerForegroundLayer(x, y);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/uk/co/shadeddimensions/ep3/client/gui/GuiRedstoneInterface.java
+++ b/src/main/java/uk/co/shadeddimensions/ep3/client/gui/GuiRedstoneInterface.java
@@ -6,15 +6,16 @@ import net.minecraft.util.ResourceLocation;
 import uk.co.shadeddimensions.ep3.lib.Localization;
 import uk.co.shadeddimensions.ep3.network.PacketHandlerClient;
 import uk.co.shadeddimensions.ep3.tileentity.portal.TileRedstoneInterface;
-import uk.co.shadeddimensions.library.gui.GuiBase;
+import uk.co.shadeddimensions.library.gui.GuiBaseContainer;
 
-public class GuiRedstoneInterface extends GuiBase
+public class GuiRedstoneInterface extends GuiBaseContainer
 {
     public TileRedstoneInterface redstone;
 
     public GuiRedstoneInterface(TileRedstoneInterface tile)
     {
         super(new ResourceLocation("enhancedportals", "textures/gui/redstoneInterface.png"));
+        drawInventory = false;
         redstone = tile;
         ySize = 58;
     }
@@ -28,11 +29,11 @@ public class GuiRedstoneInterface extends GuiBase
     }
 
     @Override
-    public void drawGuiForegroundLayer(int par1, int par2)
+    public void drawGuiContainerForegroundLayer(int par1, int par2)
     {
         drawCenteredString(fontRenderer, Localization.getGuiString("redstoneInterface"), xSize / 2, -13, 0xFFFFFF);
 
-        super.drawGuiForegroundLayer(par1, par2);
+        super.drawGuiContainerForegroundLayer(par1, par2);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Some GUIs used a container on the server-side, but not the client-side. When opening GUIs, the window IDs of the containers are synced to allow for client-server interaction. Since the client's container was not updated, this resulted in the player inventory ID (default container) getting synced with the portal GUI, causing the inventory to no longer sync with the server until the player re-logs.

I've changed all GUIs using containers to inherit from GuiBaseContainer, instead of GuiBase, which fixes the desync.
