### PR TITLE
Fixed string parameter conversion for OC

### DIFF
--- a/src/main/java/uk/co/shadeddimensions/ep3/util/ComputerUtils.java
+++ b/src/main/java/uk/co/shadeddimensions/ep3/util/ComputerUtils.java
@@ -6,8 +6,18 @@ import uk.co.shadeddimensions.ep3.portal.GlyphIdentifier;
 public class ComputerUtils {
 	public static Object[] argsToArray(Arguments args) {
 		Object[] data = new Object[args.count()];
-		for(int i = 0; i < data.length; i++)
-			data[i] = args.checkAny(i);
+		for(int i = 0; i < data.length; i++) {
+			// The explicit check for strings is required because OC returns
+			// them as byte arrays otherwise (because that's what they are in
+			// Lua). Which is usually not what we wan when auto-converting.
+			if (args.isString(i)) {
+				data[i] = args.checkString(i);
+			}
+			else
+			{
+				data[i] = args.checkAny(i);
+			}
+		} 
 		return data;
 	}
 	


### PR DESCRIPTION
OpenComputers returns strings as byte arrays from `Arguments.checkAny` (because that's what Lua spits out), so they have to be converted to actual strings first to be used as such. Usually this is done via `Arguments.checkString`, but in the current implementation all arguments are automatically parsed into an array using checkAny, so this conversion has to be applied manually (because checkAny intentionally does not change the underlying value).

As it currently is, some methods can not be used properly, because the passed strings will arrive as byte arrays in the underlying implementation, which will then error.

Note that this is _not tested_! It should work, but consider this a suggestion instead of a patch until somebody actually tests it ;-)
