### PR TITLE
Forge 1147 compatibility fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-EnhancedPortals 3 - for Minecraft 1.7.10
+EnhancedPortals 3 - for Minecraft 1.7.2
 ---
 Useful Links:
-* [Downloads](http://mods.atomicbase.com/enhancedportals/1.7.10/downloads/)
+* [Downloads](http://mods.atomicbase.com/enhancedportals/1.7.2/downloads/)
 * [Minecraft Forums Thread](http://www.minecraftforum.net/topic/2143651-164-enhancedportals-3/)
 
 

--- a/build.properties
+++ b/build.properties
@@ -1,4 +1,4 @@
-minecraft_version=1.7.10
-forge_version=10.13.0.1199
+minecraft_version=1.7.2
+forge_version=10.12.2.1147
 mod_version=3.0.4
 mod_id=enhancedportals

--- a/src/main/java/enhancedportals/tileentity/TileTransferFluid.java
+++ b/src/main/java/enhancedportals/tileentity/TileTransferFluid.java
@@ -184,7 +184,7 @@ public class TileTransferFluid extends TileFrameTransfer implements IFluidHandle
             if (fluid != null)
             {
                 map.put("name", fluid.getName());
-                map.put("label", fluid.getLocalizedName(tank.getFluid()));
+                map.put("label", fluid.getLocalizedName());
             }
         }
         else


### PR DESCRIPTION
downported from 1.7.10 and Forge 1199. Only one error that was an older
method for fluids in forge.
